### PR TITLE
[Bug] Fix use of wrong function

### DIFF
--- a/lua/bento/init.lua
+++ b/lua/bento/init.lua
@@ -215,7 +215,7 @@ M.actions = {
             end
 
             vim.api.nvim_buf_delete(buf_id, { force = false })
-            require("bento.ui").render_expanded()
+            require("bento.ui").refresh_menu()
         end,
     },
     vsplit = {


### PR DESCRIPTION
Due to the change from #14 in init.lua:

```patch
-            require("bento.ui").refresh_menu()
+            require("bento.ui").render_expanded()
```

I get the error "attempt to reference nil value", as `render_expanded()` is a local function for ui.lua.

Changing this back to `refresh_menu()` fixes the issue.