### PR TITLE
feat: support centered placement and left-aligned content for floating UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ require("bento").setup({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `position` | string | `"middle-right"` | Menu position: `"top-left"`, `"top-right"`, `"middle-left"`, `"middle-right"`, `"bottom-left"`, `"bottom-right"` |
+| `position` | string | `"middle-right"` | Menu position: `"top-left"`, `"top-center"`, `"top-right"`, `"middle-left"`, `"middle-center"`, `"middle-right"`, `"bottom-left"`, `"bottom-center"`, `"bottom-right"` (aliases: `"middle"`, `"center"`) |
+| `alignment` | string | `"right"` | Content alignment: `"right"` (labels right-aligned) or `"left"` (labels/shortcuts on the left, filenames left-aligned) |
 | `offset_x` | number | `0` | Horizontal offset from position |
 | `offset_y` | number | `0` | Vertical offset from position |
 | `dash_char` | string | `"─"` | Character for collapsed state lines |

--- a/lua/bento/init.lua
+++ b/lua/bento/init.lua
@@ -877,6 +877,7 @@ function M.setup(config)
             mode = "floating", -- "floating" | "tabline"
             floating = {
                 position = "middle-right",
+                alignment = "right", -- "left" or "right". "left" renders labels/shortcuts at the left.
                 offset_x = 0,
                 offset_y = 0,
                 dash_char = "─",


### PR DESCRIPTION
## Changes
- Add `*-center` floating positions and `middle`/`center` aliases for centered horizontal placement
- Add `ui.floating.alignment` (`left`/`right`) to control label/filename alignment
- Update README to document the new options
<img width="1642" height="567" alt="image" src="https://github.com/user-attachments/assets/414bd3aa-1b78-4783-8dd3-003087f1a034" />


## Notes
- Default behavior unchanged unless configured