### PR TITLE
feat: add floating UI title options (title/title_pos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,19 +237,11 @@ require("bento").setup({
 | `offset_y` | number | `0` | Vertical offset from position |
 | `dash_char` | string | `"─"` | Character for collapsed state lines |
 | `border` | string | `"none"` | Border style for the floating window: `"rounded"`, `"single"`, `"double"`, etc. (see :h winborder) |
-| `window` | table | See below | Extra options passed to `nvim_open_win` / `nvim_win_set_config` (e.g. `title`, `title_pos`, `style`). `window.border` overrides `border` when set. |
+| `title` | string/nil | `nil` | Optional border title (floating UI only) |
+| `title_pos` | string | `"center"` | Title alignment: `"left"`, `"center"`, `"right"` (only applied when `title` is set) |
 | `label_padding` | number | `1` | Padding on left/right of labels |
 | `minimal_menu` | string/nil | `nil` | Collapsed menu style: `nil` (hidden), `"dashed"` (dash lines), `"filename"` (names only), `"full"` (names + labels) |
 | `max_rendered_buffers` | number/nil | `nil` | Maximum buffers to display per page. Pagination is also automatically enabled when buffers exceed available screen height. Uses `min(max_rendered_buffers, available_height)` when set. Navigate pages with `[` and `]` keys. A centered indicator (`● ○ ○`) shows current page. |
-
-#### Floating Window Options (`ui.floating.window`)
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `style` | string | `"minimal"` | Window style (currently only `"minimal"` is supported) |
-| `border` | string/table | `"none"` | Border passed to `nvim_open_win` (e.g. `"single"`, `"rounded"`, etc.) |
-| `title` | string/nil | `nil` | Optional border title |
-| `title_pos` | string | `"center"` | Title alignment: `"left"`, `"center"`, `"right"` |
 
 #### Tabline UI Options (`ui.tabline`)
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,19 @@ require("bento").setup({
 | `offset_y` | number | `0` | Vertical offset from position |
 | `dash_char` | string | `"─"` | Character for collapsed state lines |
 | `border` | string | `"none"` | Border style for the floating window: `"rounded"`, `"single"`, `"double"`, etc. (see :h winborder) |
+| `window` | table | See below | Extra options passed to `nvim_open_win` / `nvim_win_set_config` (e.g. `title`, `title_pos`, `style`). `window.border` overrides `border` when set. |
 | `label_padding` | number | `1` | Padding on left/right of labels |
 | `minimal_menu` | string/nil | `nil` | Collapsed menu style: `nil` (hidden), `"dashed"` (dash lines), `"filename"` (names only), `"full"` (names + labels) |
 | `max_rendered_buffers` | number/nil | `nil` | Maximum buffers to display per page. Pagination is also automatically enabled when buffers exceed available screen height. Uses `min(max_rendered_buffers, available_height)` when set. Navigate pages with `[` and `]` keys. A centered indicator (`● ○ ○`) shows current page. |
+
+#### Floating Window Options (`ui.floating.window`)
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `style` | string | `"minimal"` | Window style (currently only `"minimal"` is supported) |
+| `border` | string/table | `"none"` | Border passed to `nvim_open_win` (e.g. `"single"`, `"rounded"`, etc.) |
+| `title` | string/nil | `nil` | Optional border title |
+| `title_pos` | string | `"center"` | Title alignment: `"left"`, `"center"`, `"right"` |
 
 #### Tabline UI Options (`ui.tabline`)
 

--- a/lua/bento/init.lua
+++ b/lua/bento/init.lua
@@ -840,9 +840,6 @@ local function validate_config(config)
         then
             return "`ui.floating` must be a table"
         end
-        if config.ui.floating and config.ui.floating.window ~= nil and type(config.ui.floating.window) ~= "table" then
-            return "`ui.floating.window` must be a table"
-        end
         if config.ui.tabline ~= nil and type(config.ui.tabline) ~= "table" then
             return "`ui.tabline` must be a table"
         end
@@ -880,16 +877,12 @@ function M.setup(config)
             mode = "floating", -- "floating" | "tabline"
             floating = {
                 position = "middle-right",
-                window = {
-                    style = "minimal",
-                    border = nil, -- nil uses `ui.floating.border`
-                    title = nil,
-                    title_pos = "center",
-                },
                 offset_x = 0,
                 offset_y = 0,
                 dash_char = "─",
                 border = "none", -- "rounded" | "single" | "double" | etc. (see :h winborder)
+                title = nil,
+                title_pos = "center", -- "left" | "center" | "right" (only applied when title is set)
                 label_padding = 1,
                 minimal_menu = nil, -- nil | "dashed" | "filename" | "full"
                 max_rendered_buffers = nil, -- nil (no limit) or number

--- a/lua/bento/init.lua
+++ b/lua/bento/init.lua
@@ -840,6 +840,9 @@ local function validate_config(config)
         then
             return "`ui.floating` must be a table"
         end
+        if config.ui.floating and config.ui.floating.window ~= nil and type(config.ui.floating.window) ~= "table" then
+            return "`ui.floating.window` must be a table"
+        end
         if config.ui.tabline ~= nil and type(config.ui.tabline) ~= "table" then
             return "`ui.tabline` must be a table"
         end
@@ -877,6 +880,12 @@ function M.setup(config)
             mode = "floating", -- "floating" | "tabline"
             floating = {
                 position = "middle-right",
+                window = {
+                    style = "minimal",
+                    border = nil, -- nil uses `ui.floating.border`
+                    title = nil,
+                    title_pos = "center",
+                },
                 offset_x = 0,
                 offset_y = 0,
                 dash_char = "─",

--- a/lua/bento/ui.lua
+++ b/lua/bento/ui.lua
@@ -32,6 +32,42 @@ local is_expanded = false
 --- @type string[]
 local selection_mode_keymaps = {}
 
+local function floating_window_opts()
+    config = bento.get_config()
+    local floating = config.ui and config.ui.floating or {}
+    local w = floating.window or {}
+
+    local style = w.style
+    if style ~= "minimal" then
+        style = "minimal"
+    end
+
+    local border = w.border
+    if border == nil then
+        border = floating.border or "none"
+    end
+
+    local title = w.title
+    if title ~= nil and type(title) ~= "string" then
+        title = nil
+    end
+
+    local title_pos = w.title_pos
+    if title_pos ~= "left" and title_pos ~= "center" and title_pos ~= "right" then
+        title_pos = "center"
+    end
+    if title == nil then
+        title_pos = nil
+    end
+
+    return {
+        style = style,
+        border = border,
+        title = title,
+        title_pos = title_pos,
+    }
+end
+
 --- Original keymaps to restore when exiting selection mode
 --- @type table<string, table>
 local saved_keymaps = {}
@@ -501,16 +537,20 @@ end
 --- @return {bufnr: number, win_id: number}
 local function create_window(height, width)
     local row, col = calculate_position(height, width)
+    local winopts = floating_window_opts()
 
     local bufnr = vim.api.nvim_create_buf(false, true)
     local win_id = vim.api.nvim_open_win(bufnr, false, {
         relative = "editor",
-        style = "minimal",
+        style = winopts.style,
         width = width,
         height = height,
         row = row,
         col = col,
-        border = config.ui.floating.border or "none",
+        border = winopts.border,
+        title = winopts.title,
+        title_pos = winopts.title_pos,
+        
         focusable = false,
     })
 
@@ -539,6 +579,7 @@ local function update_window_size(width, height)
     end
 
     local row, col = calculate_position(height, width)
+    local winopts = floating_window_opts()
 
     pcall(vim.api.nvim_win_set_config, bento_win_id, {
         relative = "editor",
@@ -546,6 +587,9 @@ local function update_window_size(width, height)
         height = height,
         row = row,
         col = col,
+        border = winopts.border,
+        title = winopts.title,
+        title_pos = winopts.title_pos,
     })
 end
 

--- a/lua/bento/ui.lua
+++ b/lua/bento/ui.lua
@@ -35,33 +35,19 @@ local selection_mode_keymaps = {}
 local function floating_window_opts()
     config = bento.get_config()
     local floating = config.ui and config.ui.floating or {}
-    local w = floating.window or {}
 
-    local style = w.style
-    if style ~= "minimal" then
-        style = "minimal"
-    end
-
-    local border = w.border
-    if border == nil then
-        border = floating.border or "none"
-    end
-
-    local title = w.title
+    local border = floating.border or "none"
+    local title = floating.title
     if title ~= nil and type(title) ~= "string" then
         title = nil
     end
 
-    local title_pos = w.title_pos
+    local title_pos = floating.title_pos
     if title_pos ~= "left" and title_pos ~= "center" and title_pos ~= "right" then
         title_pos = "center"
     end
-    if title == nil then
-        title_pos = nil
-    end
 
     return {
-        style = style,
         border = border,
         title = title,
         title_pos = title_pos,
@@ -540,19 +526,22 @@ local function create_window(height, width)
     local winopts = floating_window_opts()
 
     local bufnr = vim.api.nvim_create_buf(false, true)
-    local win_id = vim.api.nvim_open_win(bufnr, false, {
+    local win_config = {
         relative = "editor",
-        style = winopts.style,
+        style = "minimal",
         width = width,
         height = height,
         row = row,
         col = col,
         border = winopts.border,
-        title = winopts.title,
-        title_pos = winopts.title_pos,
-        
         focusable = false,
-    })
+    }
+    if winopts.title ~= nil then
+        win_config.title = winopts.title
+        win_config.title_pos = winopts.title_pos
+    end
+
+    local win_id = vim.api.nvim_open_win(bufnr, false, win_config)
 
     vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
     vim.api.nvim_buf_set_option(bufnr, "buftype", "nofile")
@@ -581,16 +570,20 @@ local function update_window_size(width, height)
     local row, col = calculate_position(height, width)
     local winopts = floating_window_opts()
 
-    pcall(vim.api.nvim_win_set_config, bento_win_id, {
+    local win_config = {
         relative = "editor",
         width = width,
         height = height,
         row = row,
         col = col,
         border = winopts.border,
-        title = winopts.title,
-        title_pos = winopts.title_pos,
-    })
+    }
+    if winopts.title ~= nil then
+        win_config.title = winopts.title
+        win_config.title_pos = winopts.title_pos
+    end
+
+    pcall(vim.api.nvim_win_set_config, bento_win_id, win_config)
 end
 
 --- Check if buffer is active (visible in any window)

--- a/lua/bento/ui.lua
+++ b/lua/bento/ui.lua
@@ -32,28 +32,6 @@ local is_expanded = false
 --- @type string[]
 local selection_mode_keymaps = {}
 
-local function floating_window_opts()
-    config = bento.get_config()
-    local floating = config.ui and config.ui.floating or {}
-
-    local border = floating.border or "none"
-    local title = floating.title
-    if title ~= nil and type(title) ~= "string" then
-        title = nil
-    end
-
-    local title_pos = floating.title_pos
-    if title_pos ~= "left" and title_pos ~= "center" and title_pos ~= "right" then
-        title_pos = "center"
-    end
-
-    return {
-        border = border,
-        title = title,
-        title_pos = title_pos,
-    }
-end
-
 --- Original keymaps to restore when exiting selection mode
 --- @type table<string, table>
 local saved_keymaps = {}
@@ -523,7 +501,6 @@ end
 --- @return {bufnr: number, win_id: number}
 local function create_window(height, width)
     local row, col = calculate_position(height, width)
-    local winopts = floating_window_opts()
 
     local bufnr = vim.api.nvim_create_buf(false, true)
     local win_config = {
@@ -533,12 +510,12 @@ local function create_window(height, width)
         height = height,
         row = row,
         col = col,
-        border = winopts.border,
+        border = config.ui.floating.border or "none",
         focusable = false,
+        title = config.ui.floating.title,
     }
-    if winopts.title ~= nil then
-        win_config.title = winopts.title
-        win_config.title_pos = winopts.title_pos
+    if config.ui.floating.title then
+        win_config.title_pos = config.ui.floating.title_pos
     end
 
     local win_id = vim.api.nvim_open_win(bufnr, false, win_config)
@@ -568,7 +545,6 @@ local function update_window_size(width, height)
     end
 
     local row, col = calculate_position(height, width)
-    local winopts = floating_window_opts()
 
     local win_config = {
         relative = "editor",
@@ -576,11 +552,11 @@ local function update_window_size(width, height)
         height = height,
         row = row,
         col = col,
-        border = winopts.border,
+        border = config.ui.floating.border or "none",
+        title = config.ui.floating.title,
     }
-    if winopts.title ~= nil then
-        win_config.title = winopts.title
-        win_config.title_pos = winopts.title_pos
+    if config.ui.floating.title then
+        win_config.title_pos = config.ui.floating.title_pos
     end
 
     pcall(vim.api.nvim_win_set_config, bento_win_id, win_config)


### PR DESCRIPTION
## Changes
- Add `ui.floating.title` and `ui.floating.title_pos` for floating window titles
- Only apply `title_pos` when `title` is set (avoids Neovim error)
- Update README