### PR TITLE
docs: hack path name in menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ actions = {
   local butils = require("bento.utils")
 
   -- Change from ~/home/yak/file.lua -> ~/h/y/file.lua
+  -- by default this is displayed as file.lua
   butils.get_display_names = function(paths)
     local display_names = {}
     for _, p in ipairs(paths) do

--- a/README.md
+++ b/README.md
@@ -400,6 +400,21 @@ actions = {
 }
 ```
 
+### Custom Display Names
+```lua
+  local butils = require("bento.utils")
+
+  -- Change from ~/home/yak/file.lua -> ~/h/y/file.lua
+  butils.get_display_names = function(paths)
+    local display_names = {}
+    for _, p in ipairs(paths) do
+      display_names[p] = vim.fn.pathshorten(vim.fn.fnamemodify(p, ":~:."), 1)
+    end
+    return  display_names
+  end
+  require("bento").setup(opts)
+```
+
 ## Acknowledgments & inspiration
 
 - [buffer-sticks.nvim](https://github.com/ahkohd/buffer-sticks.nvim) by [`ahkohd`](https://github.com/ahkohd): this plugin inspired some of the ideas implemented in `bento` (e.g., the dashed menu). You should also check out this plugin, it's very good and it pursues solutions to many of the same problems.

--- a/lua/bento/ui.lua
+++ b/lua/bento/ui.lua
@@ -476,6 +476,12 @@ local function calculate_position(height, width)
 
     local row, col
 
+    if position:match("center") then
+        row = math.floor((ui.height - height) / 2)
+        col = math.floor((ui.width - width) / 2)
+        return row + offset_y, col + offset_x
+    end
+
     -- Vertical positioning
     if position:match("^top") then
         row = 0

--- a/lua/bento/ui.lua
+++ b/lua/bento/ui.lua
@@ -219,7 +219,10 @@ local function update_marks()
             local a_val = bento.get_ordering_value(a.buf_id)
             local b_val = bento.get_ordering_value(b.buf_id)
 
-            if ordering_metric == "filename" or ordering_metric == "directory" then
+            if
+                ordering_metric == "filename"
+                or ordering_metric == "directory"
+            then
                 -- String comparison: ascending alphabetical
                 if a_val == b_val then
                     return a.buf_id < b.buf_id
@@ -476,17 +479,25 @@ local function calculate_position(height, width)
 
     local row, col
 
-    if position:match("center") then
+    if position:match("^middle") then
         row = math.floor((ui.height - height) / 2)
         col = math.floor((ui.width - width) / 2)
-        return row + offset_y, col + offset_x
+        return row + offset_x, col + offset_y
     end
 
     -- Vertical positioning
     if position:match("^top") then
         row = 0
+        if position:match("middle$") then
+            col = math.floor((ui.width - width) / 2)
+            return row + offset_x, col + offset_y
+        end
     elseif position:match("^bottom") then
         row = ui.height - height
+        if position:match("middle$") then
+            col = math.floor((ui.width - width) / 2)
+            return row + offset_x, col + offset_y
+        end
     else
         row = math.floor((ui.height - height) / 2)
     end


### PR DESCRIPTION
Hey ! 

I was playing around with the file display names and figured it'd be cool to let others know it's fairly easy to override :) 

Cool plugin, and thanks again !

<img width="805" height="591" alt="Screenshot 2026-02-05 at 14 50 54" src="https://github.com/user-attachments/assets/7fbe7e57-e6e3-4a7c-89db-ce1712f3007a" />

*caveat is that the modified names need to be unique (as you've painstakingly done with `M.get_display_names` already ;))
