### PR TITLE
fix: refresh on buffer file rename

### DIFF
--- a/lua/bento/init.lua
+++ b/lua/bento/init.lua
@@ -354,6 +354,14 @@ local function setup_autocmds()
     local augroup =
         vim.api.nvim_create_augroup("BentoRefresh", { clear = true })
 
+    vim.api.nvim_create_autocmd("BufFilePost", {
+        group = augroup,
+        callback = function()
+            require("bento.ui").refresh_menu()
+        end,
+        desc = "Refresh bento menu on buffer file rename",
+    })
+
     vim.api.nvim_create_autocmd(
         { "BufAdd", "BufDelete", "BufWipeout", "BufEnter", "WinEnter" },
         {

--- a/lua/bento/ui.lua
+++ b/lua/bento/ui.lua
@@ -182,6 +182,14 @@ local function update_marks()
         end
     end
 
+    -- Sync filenames for existing marks (handles file renames)
+    for _, mark in ipairs(marks) do
+        local current_name = vim.api.nvim_buf_get_name(mark.buf_id)
+        if current_name ~= "" and current_name ~= mark.filename then
+            mark.filename = current_name
+        end
+    end
+
     -- Add new buffers
     for _, buf in pairs(vim.api.nvim_list_bufs()) do
         local bufname = vim.api.nvim_buf_get_name(buf)


### PR DESCRIPTION
`marks` stored each buffer's filename once at insertion and never updated it. Renaming a file left bento displaying the stale old name since no `BufFilePost`/`BufFilePre` autocmd was registered.

- Adds a `BufFilePost` autocmd to trigger a menu refresh immediately when a buffer's filename changes
- Syncs stored `mark.filename` with the live buffer name in `update_marks()` to handle renames from any source (LSP rename, shell, Neogit, etc.)
